### PR TITLE
chore(deny.toml): ignore advisory RUSTSEC-2023-0071

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -73,7 +73,7 @@ yanked = "warn"
 notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
-ignore = []
+ignore = ["RUSTSEC-2023-0071"]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
 # will still output a note when they are encountered.


### PR DESCRIPTION
We cannot do anything about it for the time being as no remediation is
available. The rsa crate is used by sqlx when doing secure connections
to MySQL databases.
